### PR TITLE
fixing product with no rewards bug

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -59,19 +59,25 @@ def listDeals(bot, update, args):
 
 
 def format_response(product, response, format_character=''):
-    response += format_character + "Preço:" + format_character + " " + \
-        product["default_sku"]["display_price"] + "\n"
-    response += format_character + "Promoção:" + format_character + " " + \
-        product["default_sku"]["rewards"][0]["display_price"] + " (" + \
-        str(product["default_sku"]["rewards"][0]["discount"]) + "% de desconto)\n"
 
-    if "bonus_display_price" in product["default_sku"]["rewards"][0]:
-        response += format_character + "Plus:" + format_character + " " + \
-            product["default_sku"]["rewards"][0]["bonus_display_price"] + " (" + str(
-            product["default_sku"]["rewards"][0]["bonus_discount"]) + "% de desconto)\n"
+    # check if product is on sale / has discount
+    if product["default_sku"]["rewards"]:
+        response += format_character + "Preço:" + format_character + " " + \
+            product["default_sku"]["display_price"] + "\n"
+        response += format_character + "Promoção:" + format_character + " " + \
+            product["default_sku"]["rewards"][0]["display_price"] + " (" + \
+            str(product["default_sku"]["rewards"][0]["discount"]) + "% de desconto)\n"
 
-    response += format_character + "Preço promocional até " + \
-                product["default_sku"]["rewards"][0]["end_date"] + format_character + "\n"
+        if "bonus_display_price" in product["default_sku"]["rewards"][0]:
+            response += format_character + "Plus:" + format_character + " " + \
+                product["default_sku"]["rewards"][0]["bonus_display_price"] + " (" + str(
+                product["default_sku"]["rewards"][0]["bonus_discount"]) + "% de desconto)\n"
+
+        response += format_character + "Preço promocional até " + \
+                    product["default_sku"]["rewards"][0]["end_date"] + format_character + "\n"
+    else:
+        response += format_character + "Promoção:" + format_character + " Nenhum preço promocional encontrado! \n"
+
     return response
 
 


### PR DESCRIPTION
Now we can use the command `/product` to get information about any product:

![image](https://user-images.githubusercontent.com/4624484/46635925-69deaa80-cb2c-11e8-91b9-866ac2832a28.png)

![image](https://user-images.githubusercontent.com/4624484/46635934-6fd48b80-cb2c-11e8-8a89-dc5af91ec4f6.png)
